### PR TITLE
Fix Forge PR creation call signature

### DIFF
--- a/agentic.el
+++ b/agentic.el
@@ -597,20 +597,21 @@ Never returns nil; unreadable files yield \"\"."
 ;; -------------------------------------------------------------------
 
 ;;;###autoload
-(defun agentic/forge-open-pr (title body)
+(defun agentic/forge-open-pr ()
   "Open a GitHub pull request for the current branch via Forge.
 
-TITLE and BODY are used to populate the PR. Ensure `forge` is configured
-for this repository (`M-x forge-add-repository` first time)."
-  (interactive "sPR title: \nsPR body: ")
+Ensure `forge` is configured for this repository
+(`M-x forge-add-repository` first time).  The PR title/body are entered in
+Forge's submit buffer, matching `forge-create-pullreq`'s documented workflow."
+  (interactive)
   (agentic--ensure-forge)
   (let ((repo (or (forge-get-repository t)
                   (progn (call-interactively #'forge-add-repository)
                          (forge-get-repository t)))))
     (unless repo (user-error "agentic: no Forge repository configured"))
     (magit-push-current-to-pushremote nil)
-    (forge-create-pullreq repo title body)
-    (message "agentic: PR created (check your browser or Forge buffer).")))
+    (forge-create-pullreq)
+    (message "agentic: PR submit buffer opened (complete title/body in Forge).")))
 
 (provide 'agentic)
 ;;; agentic.el ends here


### PR DESCRIPTION
### Motivation
- Ensure `agentic/forge-open-pr` invokes Forge's `forge-create-pullreq` interactively per Forge's documented workflow and avoid passing unsupported positional `title`/`body` arguments.

### Description
- Remove `title` and `body` parameters from `agentic/forge-open-pr`, make the function fully interactive, call `(forge-create-pullreq)` with no args, and update the docstring and user message to indicate the PR title/body are entered in Forge's submit buffer.

### Testing
- Ran `rg -n "forge-create-pullreq|agentic/forge-open-pr" agentic.el README.md` to confirm usage and references were updated (succeeded).
- Inspected the patch with `git diff -- agentic.el` to verify the implemented changes match the intended signature update (succeeded).
- Attempted a runtime check with `emacs --batch --eval "(progn (princ (or (locate-library \"forge\") \"nil\")))"` but it could not be executed because `emacs` is not installed in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dfa735bc832086bcc3f5f61da3c1)